### PR TITLE
security: commit Gemfile.lock for CI supply chain protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
-gemfiles/*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,414 @@
+PATH
+  remote: .
+  specs:
+    rollbar (3.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.6)
+      actionpack (= 7.1.6)
+      activesupport (= 7.1.6)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.6)
+      actionpack (= 7.1.6)
+      activejob (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.6)
+      actionpack (= 7.1.6)
+      actionview (= 7.1.6)
+      activejob (= 7.1.6)
+      activesupport (= 7.1.6)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.6)
+      actionview (= 7.1.6)
+      activesupport (= 7.1.6)
+      cgi
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.6)
+      actionpack (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.1.6)
+      activesupport (= 7.1.6)
+      builder (~> 3.1)
+      cgi
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (7.1.6)
+      activesupport (= 7.1.6)
+      globalid (>= 0.3.6)
+    activemodel (7.1.6)
+      activesupport (= 7.1.6)
+    activerecord (7.1.6)
+      activemodel (= 7.1.6)
+      activesupport (= 7.1.6)
+      timeout (>= 0.4.0)
+    activestorage (7.1.6)
+      actionpack (= 7.1.6)
+      activejob (= 7.1.6)
+      activerecord (= 7.1.6)
+      activesupport (= 7.1.6)
+      marcel (~> 1.0)
+    activesupport (7.1.6)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    appraisal (2.5.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
+    ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-sqs (1.117.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    capistrano (3.20.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    cgi (0.5.2)
+    concurrent-ruby (1.3.8)
+    connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.7)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.2)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0)
+    database_cleaner-core (2.1.0)
+    date (3.5.1)
+    delayed_job (4.2.0)
+      activesupport (>= 3.0, < 9.0)
+      benchmark
+      logger
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    erb (6.0.7)
+    erubi (1.13.1)
+    generator_spec (0.10.0)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+    globalid (1.4.0)
+      activesupport (>= 6.1)
+    hashdiff (1.2.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jmespath (1.6.2)
+    json (2.21.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.2.1)
+    mini_mime (1.1.5)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mixlib-shellout (2.4.4)
+    mono_logger (1.1.2)
+    multi_json (1.21.1)
+    mustermann (3.1.1)
+    mutex_m (0.3.0)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.3)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (2.3.1)
+      rack (>= 3)
+    rails (7.1.6)
+      actioncable (= 7.1.6)
+      actionmailbox (= 7.1.6)
+      actionmailer (= 7.1.6)
+      actionpack (= 7.1.6)
+      actiontext (= 7.1.6)
+      actionview (= 7.1.6)
+      activejob (= 7.1.6)
+      activemodel (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      bundler (>= 1.15.0)
+      railties (= 7.1.6)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (7.1.6)
+      actionpack (= 7.1.6)
+      activesupport (= 7.1.6)
+      cgi
+      irb
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
+    rainbow (3.1.1)
+    rake (13.4.2)
+    rbs (4.1.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    redis (4.8.0)
+    redis-client (0.30.1)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    regexp_parser (2.12.0)
+    reline (0.7.0)
+      io-console (~> 0.5)
+    resque (1.27.4)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-command (1.0.3)
+      mixlib-shellout (~> 2.0)
+      rspec (~> 3.2)
+      rspec-its (~> 1.2)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (6.0.4)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
+    rspec-support (3.13.7)
+    rubinius-coverage (2.1)
+    rubinius-debugger (2.6)
+    rubinius-developer_tools (2.0.0)
+      rubinius-coverage (~> 2.0)
+      rubinius-debugger (~> 2.0)
+      rubinius-profiler (~> 2.0)
+    rubinius-profiler (2.1)
+    rubocop (1.15.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.5.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.19.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.13.0)
+    secure_headers (6.3.4)
+    securerandom (0.4.1)
+    shoryuken (7.0.3)
+      aws-sdk-sqs (>= 1.66.0)
+      concurrent-ruby
+      thor
+      zeitwerk (~> 2.6)
+    sidekiq (8.1.6)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.29.0)
+    simplecov (1.0.3)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sqlite3 (1.7.3-arm64-darwin)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    thor (1.5.0)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.6.0)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin-25
+
+DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter
+  appraisal
+  aws-sdk-sqs
+  capistrano
+  database_cleaner
+  delayed_job (~> 4.1)
+  generator_spec
+  jruby-openssl
+  minitest
+  racc
+  rails (~> 7.1.0)
+  rake
+  redis (<= 4.8.0)
+  resque (< 2.0.0)
+  rollbar!
+  rspec-command
+  rspec-rails (~> 6.0.3)
+  rubinius-developer_tools
+  rubocop (= 1.15.0)
+  rubocop-performance
+  secure_headers (~> 6.3.2)
+  shoryuken
+  sidekiq (>= 6.4.0)
+  simplecov
+  sinatra
+  sqlite3 (~> 1.4)
+  sucker_punch (~> 2.0)
+  webmock
+
+RUBY VERSION
+   ruby 3.2.2p53
+
+BUNDLED WITH
+   2.4.10

--- a/gemfiles/rails50.gemfile.lock
+++ b/gemfiles/rails50.gemfile.lock
@@ -1,0 +1,314 @@
+GIT
+  remote: https://github.com/sinatra/sinatra
+  revision: 2272e06adfd6d841ec0c22f7dbd433fb56498c92
+  tag: v2.0.8
+  specs:
+    rack-protection (2.0.8)
+      rack
+    sinatra (2.0.8)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8)
+      tilt (~> 2.0)
+
+PATH
+  remote: ..
+  specs:
+    rollbar (3.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (5.0.7.2)
+      actionpack (= 5.0.7.2)
+      nio4r (>= 1.2, < 3.0)
+      websocket-driver (~> 0.6.1)
+    actionmailer (5.0.7.2)
+      actionpack (= 5.0.7.2)
+      actionview (= 5.0.7.2)
+      activejob (= 5.0.7.2)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.0.7.2)
+      actionview (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      rack (~> 2.0)
+      rack-test (~> 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.0.7.2)
+      activesupport (= 5.0.7.2)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activejob (5.0.7.2)
+      activesupport (= 5.0.7.2)
+      globalid (>= 0.3.6)
+    activemodel (5.0.7.2)
+      activesupport (= 5.0.7.2)
+    activerecord (5.0.7.2)
+      activemodel (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      arel (~> 7.0)
+    activesupport (5.0.7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    arel (7.1.4)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-sqs (1.117.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    capistrano (3.20.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    concurrent-ruby (1.3.8)
+    connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.7)
+    database_cleaner (1.8.5)
+    date (3.5.1)
+    delayed_job (4.2.0)
+      activesupport (>= 3.0, < 9.0)
+      benchmark
+      logger
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    erubis (2.7.0)
+    generator_spec (0.10.0)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
+    hashdiff (1.2.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
+    json (2.21.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    method_source (1.1.0)
+    mini_mime (1.1.5)
+    minitest (5.27.0)
+    mixlib-shellout (2.4.4)
+    mono_logger (1.1.2)
+    multi_json (1.21.1)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (3.1.1)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    public_suffix (3.1.1)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails (5.0.7.2)
+      actioncable (= 5.0.7.2)
+      actionmailer (= 5.0.7.2)
+      actionpack (= 5.0.7.2)
+      actionview (= 5.0.7.2)
+      activejob (= 5.0.7.2)
+      activemodel (= 5.0.7.2)
+      activerecord (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      bundler (>= 1.3.0)
+      railties (= 5.0.7.2)
+      sprockets-rails (>= 2.0.0)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (5.0.7.2)
+      actionpack (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rake (13.4.2)
+    redis (3.3.5)
+    redis-client (0.30.1)
+      connection_pool
+    redis-namespace (1.8.2)
+      redis (>= 3.0.4)
+    resque (2.7.0)
+      mono_logger (~> 1)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 0.9.2)
+    rexml (3.4.4)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-command (1.0.3)
+      mixlib-shellout (~> 2.0)
+      rspec (~> 3.2)
+      rspec-its (~> 1.2)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-rails (3.5.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rubinius-coverage (2.1)
+    rubinius-debugger (2.6)
+    rubinius-developer_tools (2.0.0)
+      rubinius-coverage (~> 2.0)
+      rubinius-debugger (~> 2.0)
+      rubinius-profiler (~> 2.0)
+    rubinius-profiler (2.1)
+    ruby2_keywords (0.0.5)
+    secure_headers (6.3.4)
+    shoryuken (7.0.3)
+      aws-sdk-sqs (>= 1.66.0)
+      concurrent-ruby
+      thor
+      zeitwerk (~> 2.6)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sprockets (4.2.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.2.2)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    thor (1.5.0)
+    thread_safe (0.3.6)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.6.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin-25
+
+DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter
+  aws-sdk-sqs
+  capistrano
+  database_cleaner (~> 1.8.4)
+  delayed_job
+  generator_spec
+  jruby-openssl
+  minitest
+  net-ssh (<= 3.1.1)
+  public_suffix (<= 3.1.1)
+  racc
+  rails (~> 5.0.7)
+  rake
+  redis (<= 3.3.5)
+  resque
+  rollbar!
+  rspec-command
+  rspec-core (~> 3.5.0.beta3)
+  rspec-expectations (~> 3.5.0.beta3)
+  rspec-mocks (~> 3.5.0.beta3)
+  rspec-rails (~> 3.5.0.beta3)
+  rspec-support (~> 3.5.0.beta3)
+  rubinius-developer_tools
+  secure_headers (~> 6.3.2)
+  shoryuken
+  sidekiq (>= 2.13.0)
+  simplecov (<= 0.17.1)
+  sinatra!
+  sqlite3 (< 1.4.0)
+  sucker_punch (~> 2.0)
+  webmock
+
+BUNDLED WITH
+   2.4.10

--- a/gemfiles/rails51.gemfile.lock
+++ b/gemfiles/rails51.gemfile.lock
@@ -1,0 +1,314 @@
+GIT
+  remote: https://github.com/sinatra/sinatra
+  revision: 2272e06adfd6d841ec0c22f7dbd433fb56498c92
+  tag: v2.0.8
+  specs:
+    rack-protection (2.0.8)
+      rack
+    sinatra (2.0.8)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8)
+      tilt (~> 2.0)
+
+PATH
+  remote: ..
+  specs:
+    rollbar (3.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (5.1.7)
+      actionpack (= 5.1.7)
+      nio4r (~> 2.0)
+      websocket-driver (~> 0.6.1)
+    actionmailer (5.1.7)
+      actionpack (= 5.1.7)
+      actionview (= 5.1.7)
+      activejob (= 5.1.7)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.1.7)
+      actionview (= 5.1.7)
+      activesupport (= 5.1.7)
+      rack (~> 2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.1.7)
+      activesupport (= 5.1.7)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activejob (5.1.7)
+      activesupport (= 5.1.7)
+      globalid (>= 0.3.6)
+    activemodel (5.1.7)
+      activesupport (= 5.1.7)
+    activerecord (5.1.7)
+      activemodel (= 5.1.7)
+      activesupport (= 5.1.7)
+      arel (~> 8.0)
+    activesupport (5.1.7)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    arel (8.0.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-sqs (1.117.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    capistrano (3.20.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    concurrent-ruby (1.3.8)
+    connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.7)
+    database_cleaner (1.8.5)
+    date (3.5.1)
+    delayed_job (4.2.0)
+      activesupport (>= 3.0, < 9.0)
+      benchmark
+      logger
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    erubi (1.13.1)
+    generator_spec (0.10.0)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
+    hashdiff (1.2.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
+    json (2.21.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    method_source (1.1.0)
+    mini_mime (1.1.5)
+    minitest (5.27.0)
+    mixlib-shellout (2.4.4)
+    mono_logger (1.1.2)
+    multi_json (1.21.1)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (3.1.1)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    public_suffix (3.1.1)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rails (5.1.7)
+      actioncable (= 5.1.7)
+      actionmailer (= 5.1.7)
+      actionpack (= 5.1.7)
+      actionview (= 5.1.7)
+      activejob (= 5.1.7)
+      activemodel (= 5.1.7)
+      activerecord (= 5.1.7)
+      activesupport (= 5.1.7)
+      bundler (>= 1.3.0)
+      railties (= 5.1.7)
+      sprockets-rails (>= 2.0.0)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (5.1.7)
+      actionpack (= 5.1.7)
+      activesupport (= 5.1.7)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rake (13.4.2)
+    redis (3.3.5)
+    redis-client (0.30.1)
+      connection_pool
+    redis-namespace (1.8.2)
+      redis (>= 3.0.4)
+    resque (2.7.0)
+      mono_logger (~> 1)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 0.9.2)
+    rexml (3.4.4)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-command (1.0.3)
+      mixlib-shellout (~> 2.0)
+      rspec (~> 3.2)
+      rspec-its (~> 1.2)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-rails (3.5.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rubinius-coverage (2.1)
+    rubinius-debugger (2.6)
+    rubinius-developer_tools (2.0.0)
+      rubinius-coverage (~> 2.0)
+      rubinius-debugger (~> 2.0)
+      rubinius-profiler (~> 2.0)
+    rubinius-profiler (2.1)
+    ruby2_keywords (0.0.5)
+    secure_headers (6.3.4)
+    shoryuken (7.0.3)
+      aws-sdk-sqs (>= 1.66.0)
+      concurrent-ruby
+      thor
+      zeitwerk (~> 2.6)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sprockets (4.2.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.2.2)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    thor (1.5.0)
+    thread_safe (0.3.6)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.6.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin-25
+
+DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter
+  aws-sdk-sqs
+  capistrano
+  database_cleaner (~> 1.8.4)
+  delayed_job
+  generator_spec
+  jruby-openssl
+  minitest
+  net-ssh (<= 3.1.1)
+  public_suffix (<= 3.1.1)
+  racc
+  rails (~> 5.1.7)
+  rake
+  redis (<= 3.3.5)
+  resque
+  rollbar!
+  rspec-command
+  rspec-core (~> 3.5.0.beta3)
+  rspec-expectations (~> 3.5.0.beta3)
+  rspec-mocks (~> 3.5.0.beta3)
+  rspec-rails (~> 3.5.0.beta3)
+  rspec-support (~> 3.5.0.beta3)
+  rubinius-developer_tools
+  secure_headers (~> 6.3.2)
+  shoryuken
+  sidekiq (>= 2.13.0)
+  simplecov (<= 0.17.1)
+  sinatra!
+  sqlite3 (< 1.4.0)
+  sucker_punch (~> 2.0)
+  webmock
+
+BUNDLED WITH
+   2.4.10

--- a/gemfiles/rails52.gemfile.lock
+++ b/gemfiles/rails52.gemfile.lock
@@ -1,0 +1,332 @@
+GIT
+  remote: https://github.com/sinatra/sinatra
+  revision: 957ce355fc2ae0eeb3af26d0a23ca2e7a47538c7
+  tag: v2.1.0
+  specs:
+    rack-protection (2.1.0)
+      rack
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+
+PATH
+  remote: ..
+  specs:
+    rollbar (3.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailer (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.2.8.1)
+      actionview (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      rack (~> 2.0, >= 2.0.8)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.8.1)
+      activesupport (= 5.2.8.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activejob (5.2.8.1)
+      activesupport (= 5.2.8.1)
+      globalid (>= 0.3.6)
+    activemodel (5.2.8.1)
+      activesupport (= 5.2.8.1)
+    activerecord (5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      arel (>= 9.0)
+    activestorage (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      activerecord (= 5.2.8.1)
+      marcel (~> 1.0.0)
+    activesupport (5.2.8.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    arel (9.0.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-sqs (1.117.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    capistrano (3.20.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    concurrent-ruby (1.3.8)
+    connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.7)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.2)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0)
+    database_cleaner-core (2.1.0)
+    date (3.5.1)
+    delayed_job (4.2.0)
+      activesupport (>= 3.0, < 9.0)
+      benchmark
+      logger
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    erubi (1.13.1)
+    generator_spec (0.10.0)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
+    hashdiff (1.2.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
+    json (2.21.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.4)
+    method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0701)
+    mini_mime (1.1.5)
+    minitest (5.27.0)
+    mixlib-shellout (2.4.4)
+    mono_logger (1.1.2)
+    multi_json (1.21.1)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.3)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rails (5.2.8.1)
+      actioncable (= 5.2.8.1)
+      actionmailer (= 5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activerecord (= 5.2.8.1)
+      activestorage (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      bundler (>= 1.3.0)
+      railties (= 5.2.8.1)
+      sprockets-rails (>= 2.0.0)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (5.2.8.1)
+      actionpack (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.19.0, < 2.0)
+    rake (13.4.2)
+    redis (4.8.0)
+    redis-client (0.30.1)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    resque (3.0.0)
+      base64 (~> 0.1)
+      logger
+      mono_logger (~> 1)
+      multi_json (~> 1.0)
+      redis (>= 4.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 2.0)
+    rexml (3.4.4)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-command (1.0.3)
+      mixlib-shellout (~> 2.0)
+      rspec (~> 3.2)
+      rspec-its (~> 1.2)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-rails (3.8.3)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.3)
+    rubinius-coverage (2.1)
+    rubinius-debugger (2.6)
+    rubinius-developer_tools (2.0.0)
+      rubinius-coverage (~> 2.0)
+      rubinius-debugger (~> 2.0)
+      rubinius-profiler (~> 2.0)
+    rubinius-profiler (2.1)
+    ruby2_keywords (0.0.5)
+    secure_headers (6.3.4)
+    shoryuken (7.0.3)
+      aws-sdk-sqs (>= 1.66.0)
+      concurrent-ruby
+      thor
+      zeitwerk (~> 2.6)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sprockets (4.2.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    thor (1.5.0)
+    thread_safe (0.3.6)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin-25
+
+DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter
+  aws-sdk-sqs
+  capistrano
+  database_cleaner
+  delayed_job
+  generator_spec
+  jruby-openssl
+  mime-types
+  minitest
+  racc
+  rails (~> 5.2.3)
+  rake
+  redis (<= 4.8.0)
+  resque
+  rollbar!
+  rspec-command
+  rspec-core (~> 3.8.0)
+  rspec-expectations (~> 3.8.0)
+  rspec-mocks (~> 3.8.0)
+  rspec-rails (~> 3.8.0)
+  rspec-support (~> 3.8.0)
+  rubinius-developer_tools
+  secure_headers (~> 6.3.2)
+  shoryuken
+  sidekiq (>= 6.4.0)
+  simplecov (<= 0.17.1)
+  sinatra!
+  sqlite3 (< 1.4.0)
+  sucker_punch (~> 2.0)
+  webmock
+
+BUNDLED WITH
+   2.4.10

--- a/gemfiles/rails60.gemfile.lock
+++ b/gemfiles/rails60.gemfile.lock
@@ -1,0 +1,334 @@
+GIT
+  remote: https://github.com/sinatra/sinatra
+  revision: 957ce355fc2ae0eeb3af26d0a23ca2e7a47538c7
+  tag: v2.1.0
+  specs:
+    rack-protection (2.1.0)
+      rack
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+
+PATH
+  remote: ..
+  specs:
+    rollbar (3.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (6.0.6.1)
+      actionpack (= 6.0.6.1)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (6.0.6.1)
+      actionpack (= 6.0.6.1)
+      activejob (= 6.0.6.1)
+      activerecord (= 6.0.6.1)
+      activestorage (= 6.0.6.1)
+      activesupport (= 6.0.6.1)
+      mail (>= 2.7.1)
+    actionmailer (6.0.6.1)
+      actionpack (= 6.0.6.1)
+      actionview (= 6.0.6.1)
+      activejob (= 6.0.6.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (6.0.6.1)
+      actionview (= 6.0.6.1)
+      activesupport (= 6.0.6.1)
+      rack (~> 2.0, >= 2.0.8)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (6.0.6.1)
+      actionpack (= 6.0.6.1)
+      activerecord (= 6.0.6.1)
+      activestorage (= 6.0.6.1)
+      activesupport (= 6.0.6.1)
+      nokogiri (>= 1.8.5)
+    actionview (6.0.6.1)
+      activesupport (= 6.0.6.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (6.0.6.1)
+      activesupport (= 6.0.6.1)
+      globalid (>= 0.3.6)
+    activemodel (6.0.6.1)
+      activesupport (= 6.0.6.1)
+    activerecord (6.0.6.1)
+      activemodel (= 6.0.6.1)
+      activesupport (= 6.0.6.1)
+    activestorage (6.0.6.1)
+      actionpack (= 6.0.6.1)
+      activejob (= 6.0.6.1)
+      activerecord (= 6.0.6.1)
+      marcel (~> 1.0)
+    activesupport (6.0.6.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-sqs (1.117.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    capistrano (3.20.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    concurrent-ruby (1.3.8)
+    connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.7)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.2)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0)
+    database_cleaner-core (2.1.0)
+    date (3.5.1)
+    delayed_job (4.1.9)
+      activesupport (>= 3.0, < 6.2)
+    diff-lcs (1.6.2)
+    erubi (1.13.1)
+    generator_spec (0.10.0)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
+    hashdiff (1.2.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.2.1)
+    method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0701)
+    mini_mime (1.1.5)
+    minitest (5.27.0)
+    mixlib-shellout (2.4.4)
+    mono_logger (1.1.2)
+    multi_json (1.21.1)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.3)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rails (6.0.6.1)
+      actioncable (= 6.0.6.1)
+      actionmailbox (= 6.0.6.1)
+      actionmailer (= 6.0.6.1)
+      actionpack (= 6.0.6.1)
+      actiontext (= 6.0.6.1)
+      actionview (= 6.0.6.1)
+      activejob (= 6.0.6.1)
+      activemodel (= 6.0.6.1)
+      activerecord (= 6.0.6.1)
+      activestorage (= 6.0.6.1)
+      activesupport (= 6.0.6.1)
+      bundler (>= 1.3.0)
+      railties (= 6.0.6.1)
+      sprockets-rails (>= 2.0.0)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (6.0.6.1)
+      actionpack (= 6.0.6.1)
+      activesupport (= 6.0.6.1)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.20.3, < 2.0)
+    rake (13.4.2)
+    redis (4.8.0)
+    redis-client (0.30.1)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    resque (3.0.0)
+      base64 (~> 0.1)
+      logger
+      mono_logger (~> 1)
+      multi_json (~> 1.0)
+      redis (>= 4.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 2.0)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-command (1.0.3)
+      mixlib-shellout (~> 2.0)
+      rspec (~> 3.2)
+      rspec-its (~> 1.2)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (4.0.2)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.10)
+      rspec-expectations (~> 3.10)
+      rspec-mocks (~> 3.10)
+      rspec-support (~> 3.10)
+    rspec-support (3.13.7)
+    rubinius-coverage (2.1)
+    rubinius-debugger (2.6)
+    rubinius-developer_tools (2.0.0)
+      rubinius-coverage (~> 2.0)
+      rubinius-debugger (~> 2.0)
+      rubinius-profiler (~> 2.0)
+    rubinius-profiler (2.1)
+    ruby2_keywords (0.0.5)
+    secure_headers (6.3.4)
+    shoryuken (7.0.3)
+      aws-sdk-sqs (>= 1.66.0)
+      concurrent-ruby
+      thor
+      zeitwerk (~> 2.6)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
+    simplecov (1.0.3)
+    sprockets (4.2.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.7.3-arm64-darwin)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    thor (1.5.0)
+    thread_safe (0.3.6)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin-25
+
+DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter
+  aws-sdk-sqs
+  capistrano
+  database_cleaner
+  delayed_job (= 4.1.9)
+  generator_spec
+  jruby-openssl
+  mime-types
+  minitest
+  racc
+  rails (~> 6.0.2)
+  rake
+  redis (<= 4.8.0)
+  resque
+  rollbar!
+  rspec-command
+  rspec-rails (~> 4.0.2)
+  rubinius-developer_tools
+  secure_headers (~> 6.3.2)
+  shoryuken
+  sidekiq (>= 6.4.0)
+  simplecov
+  sinatra!
+  sqlite3 (~> 1.4)
+  sucker_punch (~> 2.0)
+  webmock
+
+BUNDLED WITH
+   2.4.10

--- a/gemfiles/rails61.gemfile.lock
+++ b/gemfiles/rails61.gemfile.lock
@@ -1,0 +1,341 @@
+GIT
+  remote: https://github.com/sinatra/sinatra
+  revision: 957ce355fc2ae0eeb3af26d0a23ca2e7a47538c7
+  tag: v2.1.0
+  specs:
+    rack-protection (2.1.0)
+      rack
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+
+PATH
+  remote: ..
+  specs:
+    rollbar (3.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (6.1.7.10)
+      actionpack (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (6.1.7.10)
+      actionpack (= 6.1.7.10)
+      activejob (= 6.1.7.10)
+      activerecord (= 6.1.7.10)
+      activestorage (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+      mail (>= 2.7.1)
+    actionmailer (6.1.7.10)
+      actionpack (= 6.1.7.10)
+      actionview (= 6.1.7.10)
+      activejob (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (6.1.7.10)
+      actionview (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+      rack (~> 2.0, >= 2.0.9)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (6.1.7.10)
+      actionpack (= 6.1.7.10)
+      activerecord (= 6.1.7.10)
+      activestorage (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+      nokogiri (>= 1.8.5)
+    actionview (6.1.7.10)
+      activesupport (= 6.1.7.10)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (6.1.7.10)
+      activesupport (= 6.1.7.10)
+      globalid (>= 0.3.6)
+    activemodel (6.1.7.10)
+      activesupport (= 6.1.7.10)
+    activerecord (6.1.7.10)
+      activemodel (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+    activestorage (6.1.7.10)
+      actionpack (= 6.1.7.10)
+      activejob (= 6.1.7.10)
+      activerecord (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (6.1.7.10)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-sqs (1.117.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    capistrano (3.20.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    concurrent-ruby (1.3.8)
+    connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.7)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.2)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0)
+    database_cleaner-core (2.1.0)
+    date (3.5.1)
+    delayed_job (4.1.9)
+      activesupport (>= 3.0, < 6.2)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    erubi (1.13.1)
+    generator_spec (0.10.0)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+    globalid (1.4.0)
+      activesupport (>= 6.1)
+    hashdiff (1.2.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.2.1)
+    method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0701)
+    mini_mime (1.1.5)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mixlib-shellout (2.4.4)
+    mono_logger (1.1.2)
+    multi_json (1.21.1)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.3)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    prism (1.9.0)
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rails (6.1.7.10)
+      actioncable (= 6.1.7.10)
+      actionmailbox (= 6.1.7.10)
+      actionmailer (= 6.1.7.10)
+      actionpack (= 6.1.7.10)
+      actiontext (= 6.1.7.10)
+      actionview (= 6.1.7.10)
+      activejob (= 6.1.7.10)
+      activemodel (= 6.1.7.10)
+      activerecord (= 6.1.7.10)
+      activestorage (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+      bundler (>= 1.15.0)
+      railties (= 6.1.7.10)
+      sprockets-rails (>= 2.0.0)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (6.1.7.10)
+      actionpack (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+    rake (13.4.2)
+    redis (4.8.0)
+    redis-client (0.30.1)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    resque (3.0.0)
+      base64 (~> 0.1)
+      logger
+      mono_logger (~> 1)
+      multi_json (~> 1.0)
+      redis (>= 4.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 2.0)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-command (1.0.3)
+      mixlib-shellout (~> 2.0)
+      rspec (~> 3.2)
+      rspec-its (~> 1.2)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (4.0.2)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.10)
+      rspec-expectations (~> 3.10)
+      rspec-mocks (~> 3.10)
+      rspec-support (~> 3.10)
+    rspec-support (3.13.7)
+    rubinius-coverage (2.1)
+    rubinius-debugger (2.6)
+    rubinius-developer_tools (2.0.0)
+      rubinius-coverage (~> 2.0)
+      rubinius-debugger (~> 2.0)
+      rubinius-profiler (~> 2.0)
+    rubinius-profiler (2.1)
+    ruby2_keywords (0.0.5)
+    secure_headers (6.3.4)
+    shoryuken (7.0.3)
+      aws-sdk-sqs (>= 1.66.0)
+      concurrent-ruby
+      thor
+      zeitwerk (~> 2.6)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
+    simplecov (1.0.3)
+    sprockets (4.2.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.5.2)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.7.3-arm64-darwin)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    thor (1.5.0)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin-25
+
+DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter
+  aws-sdk-sqs
+  capistrano
+  database_cleaner
+  delayed_job (= 4.1.9)
+  generator_spec
+  jruby-openssl
+  mime-types
+  minitest
+  racc
+  rails (~> 6.1.5)
+  rake
+  redis (<= 4.8.0)
+  resque
+  rollbar!
+  rspec-command
+  rspec-rails (~> 4.0.2)
+  rubinius-developer_tools
+  secure_headers (~> 6.3.2)
+  shoryuken
+  sidekiq (>= 6.4.0)
+  simplecov
+  sinatra!
+  sqlite3 (~> 1.4)
+  sucker_punch (~> 2.0)
+  webmock
+
+BUNDLED WITH
+   2.4.10

--- a/gemfiles/rails70.gemfile.lock
+++ b/gemfiles/rails70.gemfile.lock
@@ -1,0 +1,350 @@
+GIT
+  remote: https://github.com/sinatra/sinatra
+  revision: 957ce355fc2ae0eeb3af26d0a23ca2e7a47538c7
+  tag: v2.1.0
+  specs:
+    rack-protection (2.1.0)
+      rack
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+
+PATH
+  remote: ..
+  specs:
+    rollbar (3.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.10)
+      actionpack (= 7.0.10)
+      activesupport (= 7.0.10)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.10)
+      actionpack (= 7.0.10)
+      activejob (= 7.0.10)
+      activerecord (= 7.0.10)
+      activestorage (= 7.0.10)
+      activesupport (= 7.0.10)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.10)
+      actionpack (= 7.0.10)
+      actionview (= 7.0.10)
+      activejob (= 7.0.10)
+      activesupport (= 7.0.10)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.10)
+      actionview (= 7.0.10)
+      activesupport (= 7.0.10)
+      racc
+      rack (~> 2.0, >= 2.2.4)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.10)
+      actionpack (= 7.0.10)
+      activerecord (= 7.0.10)
+      activestorage (= 7.0.10)
+      activesupport (= 7.0.10)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.10)
+      activesupport (= 7.0.10)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.10)
+      activesupport (= 7.0.10)
+      globalid (>= 0.3.6)
+    activemodel (7.0.10)
+      activesupport (= 7.0.10)
+    activerecord (7.0.10)
+      activemodel (= 7.0.10)
+      activesupport (= 7.0.10)
+    activestorage (7.0.10)
+      actionpack (= 7.0.10)
+      activejob (= 7.0.10)
+      activerecord (= 7.0.10)
+      activesupport (= 7.0.10)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.10)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-sqs (1.117.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    capistrano (3.20.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    concurrent-ruby (1.3.8)
+    connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.7)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.2)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0)
+    database_cleaner-core (2.1.0)
+    date (3.5.1)
+    delayed_job (4.1.10)
+      activesupport (>= 3.0, < 8.0)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    erubi (1.13.1)
+    generator_spec (0.10.0)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+    globalid (1.4.0)
+      activesupport (>= 6.1)
+    hashdiff (1.2.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.2.1)
+    method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0701)
+    mini_mime (1.1.5)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mixlib-shellout (2.4.4)
+    mono_logger (1.1.2)
+    multi_json (1.21.1)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    mutex_m (0.3.0)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.3)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    prism (1.9.0)
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rails (7.0.10)
+      actioncable (= 7.0.10)
+      actionmailbox (= 7.0.10)
+      actionmailer (= 7.0.10)
+      actionpack (= 7.0.10)
+      actiontext (= 7.0.10)
+      actionview (= 7.0.10)
+      activejob (= 7.0.10)
+      activemodel (= 7.0.10)
+      activerecord (= 7.0.10)
+      activestorage (= 7.0.10)
+      activesupport (= 7.0.10)
+      bundler (>= 1.15.0)
+      railties (= 7.0.10)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (7.0.10)
+      actionpack (= 7.0.10)
+      activesupport (= 7.0.10)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+    rake (13.4.2)
+    redis (4.8.0)
+    redis-client (0.30.1)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    resque (3.0.0)
+      base64 (~> 0.1)
+      logger
+      mono_logger (~> 1)
+      multi_json (~> 1.0)
+      redis (>= 4.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 2.0)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-command (1.0.3)
+      mixlib-shellout (~> 2.0)
+      rspec (~> 3.2)
+      rspec-its (~> 1.2)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (6.0.4)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
+    rspec-support (3.13.7)
+    rubinius-coverage (2.1)
+    rubinius-debugger (2.6)
+    rubinius-developer_tools (2.0.0)
+      rubinius-coverage (~> 2.0)
+      rubinius-debugger (~> 2.0)
+      rubinius-profiler (~> 2.0)
+    rubinius-profiler (2.1)
+    ruby2_keywords (0.0.5)
+    secure_headers (6.3.4)
+    securerandom (0.4.1)
+    shoryuken (7.0.3)
+      aws-sdk-sqs (>= 1.66.0)
+      concurrent-ruby
+      thor
+      zeitwerk (~> 2.6)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
+    simplecov (1.0.3)
+    sqlite3 (1.7.3-arm64-darwin)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    thor (1.5.0)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin-25
+
+DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter
+  aws-sdk-sqs
+  capistrano
+  database_cleaner
+  delayed_job (= 4.1.10)
+  generator_spec
+  jruby-openssl
+  mime-types
+  minitest
+  racc
+  rails (~> 7.0.8)
+  rake
+  redis (<= 4.8.0)
+  resque
+  rollbar!
+  rspec-command
+  rspec-rails (~> 6.0.3)
+  rubinius-developer_tools
+  secure_headers (~> 6.3.2)
+  shoryuken
+  sidekiq (>= 6.4.0)
+  simplecov
+  sinatra!
+  sqlite3 (~> 1.4)
+  sucker_punch (~> 2.0)
+  webmock
+
+BUNDLED WITH
+   2.4.10

--- a/gemfiles/rails71.gemfile.lock
+++ b/gemfiles/rails71.gemfile.lock
@@ -1,0 +1,387 @@
+GIT
+  remote: https://github.com/sinatra/sinatra
+  revision: 957ce355fc2ae0eeb3af26d0a23ca2e7a47538c7
+  tag: v2.1.0
+  specs:
+    rack-protection (2.1.0)
+      rack
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+
+PATH
+  remote: ..
+  specs:
+    rollbar (3.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.6)
+      actionpack (= 7.1.6)
+      activesupport (= 7.1.6)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.6)
+      actionpack (= 7.1.6)
+      activejob (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.6)
+      actionpack (= 7.1.6)
+      actionview (= 7.1.6)
+      activejob (= 7.1.6)
+      activesupport (= 7.1.6)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.6)
+      actionview (= 7.1.6)
+      activesupport (= 7.1.6)
+      cgi
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.6)
+      actionpack (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.1.6)
+      activesupport (= 7.1.6)
+      builder (~> 3.1)
+      cgi
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (7.1.6)
+      activesupport (= 7.1.6)
+      globalid (>= 0.3.6)
+    activemodel (7.1.6)
+      activesupport (= 7.1.6)
+    activerecord (7.1.6)
+      activemodel (= 7.1.6)
+      activesupport (= 7.1.6)
+      timeout (>= 0.4.0)
+    activestorage (7.1.6)
+      actionpack (= 7.1.6)
+      activejob (= 7.1.6)
+      activerecord (= 7.1.6)
+      activesupport (= 7.1.6)
+      marcel (~> 1.0)
+    activesupport (7.1.6)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-sqs (1.117.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    capistrano (3.20.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    cgi (0.5.2)
+    concurrent-ruby (1.3.8)
+    connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.7)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.2)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0)
+    database_cleaner-core (2.1.0)
+    date (3.5.1)
+    delayed_job (4.1.10)
+      activesupport (>= 3.0, < 8.0)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    erb (6.0.7)
+    erubi (1.13.1)
+    generator_spec (0.10.0)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
+    globalid (1.4.0)
+      activesupport (>= 6.1)
+    hashdiff (1.2.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.1)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.2.1)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0701)
+    mini_mime (1.1.5)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mixlib-shellout (2.4.4)
+    mono_logger (1.1.2)
+    multi_json (1.21.1)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    mutex_m (0.3.0)
+    net-imap (0.6.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.3)
+    nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-session (1.0.2)
+      rack (< 3)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (1.0.1)
+      rack (< 3)
+      webrick
+    rails (7.1.6)
+      actioncable (= 7.1.6)
+      actionmailbox (= 7.1.6)
+      actionmailer (= 7.1.6)
+      actionpack (= 7.1.6)
+      actiontext (= 7.1.6)
+      actionview (= 7.1.6)
+      activejob (= 7.1.6)
+      activemodel (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      bundler (>= 1.15.0)
+      railties (= 7.1.6)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (7.1.6)
+      actionpack (= 7.1.6)
+      activesupport (= 7.1.6)
+      cgi
+      irb
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
+    rake (13.4.2)
+    rbs (4.1.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    redis (4.8.0)
+    redis-client (0.30.1)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    reline (0.7.0)
+      io-console (~> 0.5)
+    resque (3.0.0)
+      base64 (~> 0.1)
+      logger
+      mono_logger (~> 1)
+      multi_json (~> 1.0)
+      redis (>= 4.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 2.0)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-command (1.0.3)
+      mixlib-shellout (~> 2.0)
+      rspec (~> 3.2)
+      rspec-its (~> 1.2)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (6.0.4)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
+    rspec-support (3.13.7)
+    rubinius-coverage (2.1)
+    rubinius-debugger (2.6)
+    rubinius-developer_tools (2.0.0)
+      rubinius-coverage (~> 2.0)
+      rubinius-debugger (~> 2.0)
+      rubinius-profiler (~> 2.0)
+    rubinius-profiler (2.1)
+    ruby2_keywords (0.0.5)
+    secure_headers (6.3.4)
+    securerandom (0.4.1)
+    shoryuken (7.0.3)
+      aws-sdk-sqs (>= 1.66.0)
+      concurrent-ruby
+      thor
+      zeitwerk (~> 2.6)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
+    simplecov (1.0.3)
+    sqlite3 (1.7.3-arm64-darwin)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    thor (1.5.0)
+    tilt (2.8.0)
+    timeout (0.6.1)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.9.2)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin-25
+
+DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter
+  aws-sdk-sqs
+  capistrano
+  database_cleaner
+  delayed_job (= 4.1.10)
+  generator_spec
+  jruby-openssl
+  mime-types
+  minitest
+  racc
+  rails (~> 7.1.0)
+  rake
+  redis (<= 4.8.0)
+  resque
+  rollbar!
+  rspec-command
+  rspec-rails (~> 6.0.3)
+  rubinius-developer_tools
+  secure_headers (~> 6.3.2)
+  shoryuken
+  sidekiq (>= 6.4.0)
+  simplecov
+  sinatra!
+  sqlite3 (~> 1.4)
+  sucker_punch (~> 2.0)
+  webmock
+
+BUNDLED WITH
+   2.4.10


### PR DESCRIPTION
## Summary

Remove `Gemfile.lock` and `gemfiles/*.lock` from `.gitignore` and commit resolved lockfiles for all gemfiles used in CI matrix.

**Jira:** [ST-3650](https://justworks.atlassian.net/browse/ST-3650)

## Why this matters

This repo uses `ruby/setup-ruby` with `bundler-cache: true` in CI (via `BUNDLE_GEMFILE` matrix) but has no committed lockfiles. Without them:

- `bundler-cache: true` does NOT enforce frozen installs — it only enables `BUNDLE_FROZEN=true` when a lockfile exists
- Every cache miss resolves the latest semver-compatible versions of all gems from RubyGems
- 12+ unversioned gems (appraisal, rake, minitest, racc, simplecov, etc.) plus 11 floating constraints resolve to whatever is newest
- The CI matrix tests against 7 Rails gemfiles, all without lockfiles

A compromised release of any dependency would execute arbitrary code in CI.

## Why committing Gemfile.lock in a gem is correct

The old Bundler guidance that gems should `.gitignore` their lockfile was based on a misunderstanding:

- A gem's `Gemfile.lock` is **never consumed by downstream users** — when someone adds this gem to their project, Bundler resolves from the `.gemspec`, not from this repo's `Gemfile.lock`
- The `Gemfile.lock` is **only used by this repo's own CI and developers** — it locks the dev/test environment
- Bundler's documentation now recommends committing it for all projects including gems

Committing the lockfile has **zero impact on consumers**. It only makes our CI deterministic and blocks supply-chain attacks.

## What this changes

1. Removes `Gemfile.lock` and `gemfiles/*.lock` from `.gitignore`
2. Commits `Gemfile.lock` (root) and `gemfiles/rails*.gemfile.lock` for each CI matrix gemfile

After this, `ruby/setup-ruby` will auto-set `BUNDLE_FROZEN=true`, causing CI to fail if lockfiles are out of date rather than silently installing different versions.

## How to update dependencies going forward

```bash
bundle update
for gf in gemfiles/rails*.gemfile; do
  BUNDLE_GEMFILE="$gf" bundle lock --update
done
git add Gemfile.lock gemfiles/*.lock
git commit -m "Update dependencies"
```

[ST-3650]: https://justworks.atlassian.net/browse/ST-3650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ