### PR TITLE
DEVEX-317 Add Backstage service catalog entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code owners for rollbar-gem
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @justworkshr/dev-ex
+* @justworkshr/security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for rollbar-gem
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @justworkshr/dev-ex

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,4 +10,4 @@ metadata:
 spec:
   lifecycle: production
   type: library
-  owner: dev-ex
+  owner: security

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: rollbar-gem
+  description: "Exception tracking and logging from Ruby to Rollbar"
+  annotations:
+    github.com/project-slug: justworkshr/rollbar-gem
+    tags:
+    - ruby
+spec:
+  lifecycle: production
+  type: library
+  owner: dev-ex


### PR DESCRIPTION
## Summary

Adds `catalog-info.yaml` and `CODEOWNERS` at the repository root to register this service in the [Backstage software catalog](https://backstage.prod.vibe.justworks.com/).

**Jira:** [DEVEX-317](https://justworks-tech.atlassian.net/browse/DEVEX-317)

This is part of an org-wide initiative to ensure all active services are registered in Backstage as the single source of truth for service metadata.

## Review checklist

- [ ] `spec.owner` — confirm this matches the correct team name in Backstage
- [ ] `spec.type` — confirm the inferred type is correct
- [ ] `spec.lifecycle` — change to `experimental` if not yet in production
- [ ] `metadata.description` — update if inaccurate
- [ ] Confirm the service appears correctly in [Backstage](https://backstage.prod.vibe.justworks.com/) after merging

[DEVEX-317]: https://justworks-tech.atlassian.net/browse/DEVEX-317